### PR TITLE
Use reverse_lazy instead of hardcoded URL for image upload

### DIFF
--- a/django_editorjs_fields/config.py
+++ b/django_editorjs_fields/config.py
@@ -1,6 +1,7 @@
 from secrets import token_urlsafe
 
 from django.conf import settings
+from django.urls import reverse_lazy
 
 DEBUG = getattr(settings, "DEBUG", False)
 
@@ -44,7 +45,7 @@ CONFIG_TOOLS = getattr(
         'Image': {
             'class': 'ImageTool',
             'inlineToolbar': True,
-            "config": {"endpoints": {"byFile": "/editorjs/image_upload/"}},
+            "config": {"endpoints": {"byFile": reverse_lazy('editorjs_image_upload')}},
         },
         'Header': {
             'class': 'Header',


### PR DESCRIPTION
This PR allows to change URL for image_upload view other than `/editorjs/image_upload/`