### PR TITLE
Fixed XSS vulnerability in embed tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,8 @@ class Post(models.Model):
     <title>Document</title>
   </head>
   <body>
-    {% load editorjs %}
-    {{ post.body_default }}
-    {{ post.body_editorjs | editorjs}}
-    {{ post.body_editorjs_text | editorjs}}
+    {% load editorjs %} {{ post.body_default }} {{ post.body_editorjs |
+    editorjs}} {{ post.body_editorjs_text | editorjs}}
   </body>
 </html>
 ```
@@ -283,20 +281,26 @@ plugin use css property [prefers-color-scheme](https://developer.mozilla.org/en-
 
 ![image](https://user-images.githubusercontent.com/6692517/124240864-3dfd8180-db2c-11eb-85c1-21f0faf41775.png)
 
+## Security
+
+For security purposes, we have added a setting for embed tag to prevent XSS.
+It's `EDITORJS_IFRAME_ALLOWED_SITES_EXEC_JS` . See more about it in the `Configure` section.
+
 ## Configure
 
 The application can be configured by editing the project's `settings.py`
 file.
 
-| Key                               | Description                                                            | Default               | Type                                                                                                                     |
-| --------------------------------- | ---------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `EDITORJS_DEFAULT_PLUGINS`        | List of plugins names Editor.js from npm                               | [See above](#plugins) | `list[str]`, `tuple[str]`                                                                                                |
-| `EDITORJS_DEFAULT_CONFIG_TOOLS`   | Map of Tools to use                                                    | [See above](#plugins) | `dict[str, dict]`                                                                                                        |
-| `EDITORJS_IMAGE_UPLOAD_PATH`      | Path uploads images                                                    | `uploads/images/`     | `str`                                                                                                                    |
-| `EDITORJS_IMAGE_UPLOAD_PATH_DATE` | Subdirectories                                                         | `%Y/%m/`              | `str`                                                                                                                    |
-| `EDITORJS_IMAGE_NAME_ORIGINAL`    | To use the original name of the image file?                            | `False`               | `bool`                                                                                                                   |
-| `EDITORJS_IMAGE_NAME`             | Image file name. Ignored when `EDITORJS_IMAGE_NAME_ORIGINAL` is `True` | `token_urlsafe(8)`    | `callable(filename: str, file: InMemoryUploadedFile)` ([docs](https://docs.djangoproject.com/en/3.0/ref/files/uploads/)) |
-| `EDITORJS_VERSION`                | Version Editor.js                                                      | `2.22.3`              | `str`                                                                                                                    |
+| Key                                     | Description                                                                       | Default               | Type                                                                                                                     |
+| --------------------------------------- | --------------------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `EDITORJS_DEFAULT_PLUGINS`              | List of plugins names Editor.js from npm                                          | [See above](#plugins) | `list[str]`, `tuple[str]`                                                                                                |
+| `EDITORJS_DEFAULT_CONFIG_TOOLS`         | Map of Tools to use                                                               | [See above](#plugins) | `dict[str, dict]`                                                                                                        |
+| `EDITORJS_IMAGE_UPLOAD_PATH`            | Path uploads images                                                               | `uploads/images/`     | `str`                                                                                                                    |
+| `EDITORJS_IFRAME_ALLOWED_SITES_EXEC_JS` | Allowed sites to execute JS in Iframe. Eg: ['www.youtube.com', 'codepen.io'] etc. | `"ALL"`               | `list`, `"ALL"`                                                                                                          |
+| `EDITORJS_IMAGE_UPLOAD_PATH_DATE`       | Subdirectories                                                                    | `%Y/%m/`              | `str`                                                                                                                    |
+| `EDITORJS_IMAGE_NAME_ORIGINAL`          | To use the original name of the image file?                                       | `False`               | `bool`                                                                                                                   |
+| `EDITORJS_IMAGE_NAME`                   | Image file name. Ignored when `EDITORJS_IMAGE_NAME_ORIGINAL` is `True`            | `token_urlsafe(8)`    | `callable(filename: str, file: InMemoryUploadedFile)` ([docs](https://docs.djangoproject.com/en/3.0/ref/files/uploads/)) |
+| `EDITORJS_VERSION`                      | Version Editor.js                                                                 | `2.22.3`              | `str`                                                                                                                    |
 
 For `EDITORJS_IMAGE_NAME` was used `from secrets import token_urlsafe`
 

--- a/django_editorjs_fields/config.py
+++ b/django_editorjs_fields/config.py
@@ -77,6 +77,9 @@ CONFIG_TOOLS = getattr(
     }
 )
 
+IFRAME_ALLOWED_SITES_EXEC_JS = getattr(
+    settings, "EDITORJS_IFRAME_ALLOWED_SITES_EXEC_JS", "ALL")  # can be "ALL" or a list of websites
+
 PLUGINS_KEYS = {
     '@editorjs/image': 'Image',
     '@editorjs/header': 'Header',

--- a/django_editorjs_fields/templatetags/editorjs.py
+++ b/django_editorjs_fields/templatetags/editorjs.py
@@ -2,6 +2,8 @@ import json
 
 from django import template
 from django.utils.safestring import mark_safe
+from django_editorjs_fields.config import IFRAME_ALLOWED_SITES_EXEC_JS
+from urllib.parse import urlparse
 
 register = template.Library()
 
@@ -94,9 +96,23 @@ def generate_embed(data):
     service = data.get('service')
     caption = data.get('caption')
     embed = data.get('embed')
-    iframe = f'<iframe src="{embed}" allow="autoplay" allowfullscreen="allowfullscreen"></iframe>'
+    website = urlparse(embed).netloc
 
-    return f'<div class="embed {service}">{iframe}{caption}</div>'
+    if (IFRAME_ALLOWED_SITES_EXEC_JS == "ALL"):
+        iframe = f'<iframe src="{embed}" allow="autoplay" allowfullscreen="allowfullscreen"></iframe>'
+
+        return f'<div class="embed {service}">{iframe}{caption}</div>'
+    else:
+        if (website in IFRAME_ALLOWED_SITES_EXEC_JS):
+            iframe = f'<iframe src="{embed}" allow="autoplay" allowfullscreen="allowfullscreen"></iframe>'
+
+            return f'<div class="embed {service}">{iframe}{caption}</div>'
+
+        else:
+            # adding sandbox attribute to disable js execution
+            iframe = f'<iframe src="{embed}" allow="autoplay" allowfullscreen="allowfullscreen" sandbox></iframe>'
+
+            return f'<div class="embed {service}">{iframe}{caption}</div>'
 
 
 def generate_link(data):


### PR DESCRIPTION
I found an XSS vulnerability in embed tag. If a bad guy has some data like this:
`
{
time: 1634699081144,
blocks: [
    {
         id: "92-sdf",
         type: "embed",
         data: {
             service: "youtube",
             embed: "http://somesite.com/evilHtml.html",
             caption: "nothing's wrong!"
         }
    }
]
}
`

And that evilHtml executes some JS in iframe, this is a very big security issue. I have fixed it by specifying a setting through which  we can specify the sites which can execute JS in iframe. eg: ['www.youtube.com', 'codepen.io'] etc.