### PR TITLE
add support for plugins linked by their full url

### DIFF
--- a/django_editorjs_fields/widgets.py
+++ b/django_editorjs_fields/widgets.py
@@ -83,7 +83,7 @@ class EditorJsWidget(widgets.Textarea):
         plugins = self.plugins or PLUGINS
 
         if plugins:
-            js_list += ['//cdn.jsdelivr.net/npm/' + p for p in plugins]
+            js_list += [(p if p.startswith('https://') else ('//cdn.jsdelivr.net/npm/' + p)) for p in plugins]
 
         js_list.append('django-editorjs-fields/js/django-editorjs-fields.js')
 


### PR DESCRIPTION
Hi.
If you add a plugin with his full url, example: 'https://cdn.jsdelivr.net/gh/mdgaziur/EditorJS-LaTeX@latest/dist/editorjs-latex.bundle-min.js', it will fail because  '//cdn.jsdelivr.net/npm/' will be prepended.
This PR fix it.