### PR TITLE
Parse regexp in custom embed services

### DIFF
--- a/django_editorjs_fields/static/django-editorjs-fields/js/django-editorjs-fields.js
+++ b/django_editorjs_fields/static/django-editorjs-fields/js/django-editorjs-fields.js
@@ -76,6 +76,15 @@
       for (var plugin in tools) {
         var cls = tools[plugin].class
 
+        if (plugin === 'embed') {
+          var services = Object.entries((tools[plugin].config || {}).services || {})
+          for (var i = 0; i < services.length; i++) {
+            if (services[i][1].regex) {
+              tools[plugin].config.services[services[i][0]].regex = new RegExp(services[i][1].regex)
+            }
+          }
+        }
+
         if (cls && window[cls] != undefined) {
           tools[plugin].class = eval(cls)
           continue


### PR DESCRIPTION
Editor.Js expects regexp in this config, but by default it is parsed as a string and it didn't work.